### PR TITLE
Import selectize.scss only after setting variables

### DIFF
--- a/src/selectize.bootstrap3.scss
+++ b/src/selectize.bootstrap3.scss
@@ -1,5 +1,3 @@
-@import 'selectize';
-
 $selectize-font-family: $font-family-base;
 $selectize-font-size: $font-size-base;
 $selectize-line-height: $line-height-computed;
@@ -42,6 +40,8 @@ $selectize-caret-margin: 0;
 $selectize-arrow-size: 5px;
 $selectize-arrow-color: $selectize-color-text;
 $selectize-arrow-offset: $selectize-padding-x + 5px;
+
+@import 'selectize';
 
 .selectize-dropdown,
 .selectize-dropdown.form-control {

--- a/src/selectize.default.scss
+++ b/src/selectize.default.scss
@@ -1,5 +1,3 @@
-@import 'selectize';
-
 $selectize-color-item: #1da7ee;
 $selectize-color-item-text: #fff;
 $selectize-color-item-active-text: #fff;
@@ -8,6 +6,8 @@ $selectize-color-item-active: #92c836;
 $selectize-color-item-active-border: #00578d;
 $selectize-width-item-border: 1px;
 $selectize-caret-margin: 0 1px;
+
+@import 'selectize';
 
 .selectize-control {
 


### PR DESCRIPTION
Apparently LESS and scss handle variable redefinition a bit differently. Currently in selectize-scss, customizing a Bootstrap variable like `$font-size-base` doesn't fully work, because `selectize.bootstrap3.scss` imports `selectize.scss` first before it sets `$selectize-font-size`. The import should be moved after the variable definitions.